### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/daohoangson/android-notification-listener/security/code-scanning/1](https://github.com/daohoangson/android-notification-listener/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only involves running tests and does not require write access, we will set `contents: read` as the minimal permission. This ensures that the workflow has only the necessary permissions to access the repository's contents for testing purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
